### PR TITLE
feat: reinstate Replit AI API with roadmap execution

### DIFF
--- a/server/api/replit-ai-enhanced.ts
+++ b/server/api/replit-ai-enhanced.ts
@@ -1,0 +1,347 @@
+import express from "express";
+import { replitAIEnhanced } from "../services/replit-ai-enhanced";
+import { storage } from "../storage";
+import { multiAIService } from "../services/multi-ai-provider";
+import { agentOrchestrationService } from "../services/agent-orchestration";
+
+const router = express.Router();
+
+// Create app from natural language description (Agent)
+router.post("/agent/create-app", async (req, res) => {
+  try {
+    const { description, userId = 1, enhancement = "ai" } = req.body;
+
+    if (!description) {
+      return res.status(400).json({ message: "App description is required" });
+    }
+
+    console.log(
+      "[Replit AI Agent] Creating app from description:",
+      description,
+    );
+
+    const result = await replitAIEnhanced.createAppFromDescription(
+      description,
+      userId,
+    );
+
+    res.json({
+      success: true,
+      project: result.project,
+      checkpoint: result.checkpoint,
+      effort: result.effort,
+      cost: result.cost,
+      message:
+        "App created successfully! Check the project workspace to see your new application.",
+    });
+  } catch (error) {
+    console.error("Error creating app with Agent:", error);
+    res.status(500).json({
+      message: "Failed to create app",
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+// Assistant endpoints
+router.post("/assistant/explain", async (req, res) => {
+  try {
+    const { code, language } = req.body;
+
+    if (!code || !language) {
+      return res
+        .status(400)
+        .json({ message: "Code and language are required" });
+    }
+
+    const result = await replitAIEnhanced.assistWithCode({
+      code,
+      language,
+      action: "explain",
+      mode: "basic", // Free explanation
+    });
+
+    res.json({
+      success: true,
+      explanation: result.result.explanation,
+      concepts: result.result.concepts,
+      cost: 0, // Basic mode is free
+    });
+  } catch (error) {
+    console.error("Error explaining code:", error);
+    res.status(500).json({ message: "Failed to explain code" });
+  }
+});
+
+router.post("/assistant/fix", async (req, res) => {
+  try {
+    const { code, language, mode = "basic" } = req.body;
+
+    if (!code || !language) {
+      return res
+        .status(400)
+        .json({ message: "Code and language are required" });
+    }
+
+    const result = await replitAIEnhanced.assistWithCode({
+      code,
+      language,
+      action: "fix",
+      mode,
+    });
+
+    res.json({
+      success: true,
+      result: result.result,
+      mode,
+      cost: result.cost,
+    });
+  } catch (error) {
+    console.error("Error fixing code:", error);
+    res.status(500).json({ message: "Failed to fix code" });
+  }
+});
+
+router.post("/assistant/add-feature", async (req, res) => {
+  try {
+    const { code, language, featureDescription, mode = "basic" } = req.body;
+
+    if (!code || !language || !featureDescription) {
+      return res
+        .status(400)
+        .json({
+          message: "Code, language, and feature description are required",
+        });
+    }
+
+    const result = await replitAIEnhanced.assistWithCode({
+      code,
+      language,
+      action: "add-feature",
+      mode,
+      context: { featureDescription },
+    });
+
+    res.json({
+      success: true,
+      result: result.result,
+      mode,
+      cost: result.cost,
+    });
+  } catch (error) {
+    console.error("Error adding feature:", error);
+    res.status(500).json({ message: "Failed to add feature" });
+  }
+});
+
+// Usage statistics
+router.get("/usage-stats/:userId", async (req, res) => {
+  try {
+    const userId = parseInt(req.params.userId);
+    const stats = await replitAIEnhanced.getUsageStats(userId);
+
+    res.json({
+      success: true,
+      stats,
+    });
+  } catch (error) {
+    console.error("Error getting usage stats:", error);
+    res.status(500).json({ message: "Failed to get usage statistics" });
+  }
+});
+
+// Get AI capabilities
+router.get("/capabilities", async (req, res) => {
+  res.json({
+    agent: {
+      features: [
+        "Natural language to complete app",
+        "Complex feature building",
+        "Effort-based pricing",
+        "Dynamic intelligence (Extended thinking & High power)",
+        "Automatic checkpoints for rollback",
+      ],
+      pricing: {
+        simple: "$0.10 - $0.20",
+        moderate: "$0.30 - $0.70",
+        complex: "$1.00 - $4.00",
+      },
+    },
+    assistant: {
+      basic: {
+        features: [
+          "Code explanation",
+          "Bug identification",
+          "Feature suggestions",
+        ],
+        cost: "Free",
+      },
+      advanced: {
+        features: [
+          "Automatic bug fixes",
+          "Feature implementation",
+          "Code refactoring",
+        ],
+        cost: "$0.05 per edit",
+      },
+    },
+  });
+});
+
+// Roadmap generation endpoint
+router.post("/roadmap/generate", async (req, res) => {
+  try {
+    const { description, projectId } = req.body;
+
+    if (!description) {
+      return res
+        .status(400)
+        .json({ message: "Project description is required" });
+    }
+
+    console.log("[Replit AI] Generating roadmap for:", description);
+
+    // Generate roadmap with suggested agents
+    const roadmapPrompt = `
+    Create a detailed development roadmap for: "${description}"
+    
+    Generate 5-8 actionable steps that cover:
+    1. Project setup and architecture
+    2. UI/UX design and layout
+    3. Core functionality implementation
+    4. Database and API integration
+    5. Testing and optimization
+    6. Deployment preparation
+    
+    For each step, suggest which type of specialist should work on it from:
+    - Developer (frontend/backend)
+    - Designer (UI/UX)
+    - Database specialist
+    - DevOps engineer
+    - QA/Testing specialist
+    - AI/ML specialist
+    
+    Return as JSON array with this structure:
+    [{
+      "id": "unique-id",
+      "title": "Step Title",
+      "description": "Detailed description of what needs to be done",
+      "suggestedAgents": ["developer", "designer"], // agent types
+      "estimatedTime": "2-3 hours",
+      "status": "pending",
+      "progress": 0
+    }]`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      roadmapPrompt,
+      "You are an expert project manager creating actionable development roadmaps.",
+      "openai",
+    );
+
+    // Clean the response content to handle markdown code blocks
+    const cleanContent = response.content.replace(/```(?:json)?/g, "").trim();
+
+    const roadmap = JSON.parse(cleanContent);
+
+    res.json({
+      success: true,
+      roadmap,
+      projectId,
+    });
+  } catch (error) {
+    console.error("Error generating roadmap:", error);
+    res.status(500).json({
+      message: "Failed to generate roadmap",
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+// Execute roadmap with agents
+router.post("/roadmap/execute", async (req, res) => {
+  try {
+    const { projectId, roadmap, assignedAgents } = req.body;
+
+    console.log(
+      "[Replit AI] Starting roadmap execution for project:",
+      projectId,
+    );
+
+    const participantIds = Array.from(
+      new Set(
+        Object.values(assignedAgents)
+          .flat()
+          .map((agent: any) => agent.id),
+      ),
+    );
+
+    // Create conversation for the project
+    const conversation = await storage.createConversation({
+      projectId,
+      title: "Roadmap Execution",
+      type: "project_discussion",
+      participants: participantIds,
+      createdBy: 0,
+    });
+
+    // Create agent session
+    const session = await storage.createAgentSession({
+      projectId,
+      conversationId: conversation.id,
+      participants: participantIds,
+      sessionType: "roadmap-execution",
+    });
+
+    // Send roadmap steps to assigned agents
+    for (const step of roadmap as any[]) {
+      await storage.createMessage({
+        conversationId: conversation.id,
+        senderId: 0,
+        senderType: "system",
+        content: `Step: ${step.title}\n${step.description}`,
+        messageType: "system",
+      });
+
+      const agents = assignedAgents[step.id] || [];
+      for (const agent of agents) {
+        const context = {
+          conversation,
+          recentMessages: await storage.getMessagesByConversation(
+            conversation.id,
+          ),
+          projectContext: { projectId },
+        };
+
+        const response = await agentOrchestrationService.generateAgentResponse(
+          agent.id,
+          `Please start working on: ${step.title} - ${step.description}`,
+          context,
+        );
+
+        await storage.createMessage({
+          conversationId: conversation.id,
+          senderId: agent.id,
+          senderType: "agent",
+          content: response.content,
+          messageType: response.messageType,
+          metadata: response.metadata,
+        });
+      }
+    }
+
+    res.json({
+      success: true,
+      sessionId: session.id,
+      conversationId: conversation.id,
+      message: "Roadmap execution started",
+    });
+  } catch (error) {
+    console.error("Error executing roadmap:", error);
+    res.status(500).json({
+      message: "Failed to start execution",
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+export default router;

--- a/server/api/replit-ai-enhanced.ts
+++ b/server/api/replit-ai-enhanced.ts
@@ -107,11 +107,9 @@ router.post("/assistant/add-feature", async (req, res) => {
     const { code, language, featureDescription, mode = "basic" } = req.body;
 
     if (!code || !language || !featureDescription) {
-      return res
-        .status(400)
-        .json({
-          message: "Code, language, and feature description are required",
-        });
+      return res.status(400).json({
+        message: "Code, language, and feature description are required",
+      });
     }
 
     const result = await replitAIEnhanced.assistWithCode({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23,6 +23,7 @@ import {
   insertProjectSchema,
   insertApiTestSchema,
 } from "@shared/schema";
+import replitAIEnhancedRouter from "./api/replit-ai-enhanced";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   const currentUserId = 1; // For demo purposes, using a fixed user ID
@@ -75,6 +76,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     });
   });
 
+  app.use("/api/replit-ai", replitAIEnhancedRouter);
+
   // ==================== CODE GENERATION ROUTES ====================
   app.post("/api/generate-code", async (req, res) => {
     try {
@@ -105,12 +108,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json(result);
     } catch (error) {
       console.error("Code generation error:", error);
-      res
-        .status(500)
-        .json({
-          message:
-            error instanceof Error ? error.message : "Failed to generate code",
-        });
+      res.status(500).json({
+        message:
+          error instanceof Error ? error.message : "Failed to generate code",
+      });
     }
   });
 
@@ -128,12 +129,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json(result);
     } catch (error) {
       console.error("Code debugging error:", error);
-      res
-        .status(500)
-        .json({
-          message:
-            error instanceof Error ? error.message : "Failed to debug code",
-        });
+      res.status(500).json({
+        message:
+          error instanceof Error ? error.message : "Failed to debug code",
+      });
     }
   });
 
@@ -544,12 +543,10 @@ This project was created with AI-powered development tools and includes:
     try {
       const token = process.env.GITHUB_TOKEN;
       if (!token) {
-        return res
-          .status(400)
-          .json({
-            message:
-              "GitHub token not configured. Please set GITHUB_TOKEN environment variable.",
-          });
+        return res.status(400).json({
+          message:
+            "GitHub token not configured. Please set GITHUB_TOKEN environment variable.",
+        });
       }
 
       const githubService = new GitHubService(token);
@@ -2029,12 +2026,10 @@ http://localhost:5000/dev/${cleanRepoName}-${project.id}
       res.json({ success: true, message: "File/folder deleted successfully" });
     } catch (error) {
       console.error("Error deleting file:", error);
-      res
-        .status(500)
-        .json({
-          message: "Failed to delete file/folder",
-          error: error.message,
-        });
+      res.status(500).json({
+        message: "Failed to delete file/folder",
+        error: error.message,
+      });
     }
   });
 
@@ -2052,12 +2047,10 @@ http://localhost:5000/dev/${cleanRepoName}-${project.id}
       res.json({ success: true, message: "File/folder renamed successfully" });
     } catch (error) {
       console.error("Error renaming file:", error);
-      res
-        .status(500)
-        .json({
-          message: "Failed to rename file/folder",
-          error: error.message,
-        });
+      res.status(500).json({
+        message: "Failed to rename file/folder",
+        error: error.message,
+      });
     }
   });
 
@@ -2496,12 +2489,10 @@ Let's discuss our approach and divide the work. Who wants to start with the plan
       res.json(result);
     } catch (error) {
       console.error("Error executing agent task:", error);
-      res
-        .status(500)
-        .json({
-          message: "Failed to execute agent task",
-          error: error.message,
-        });
+      res.status(500).json({
+        message: "Failed to execute agent task",
+        error: error.message,
+      });
     }
   });
 
@@ -2511,11 +2502,9 @@ Let's discuss our approach and divide the work. Who wants to start with the plan
       const { projectId, objective, participants } = req.body;
 
       if (!projectId || !objective || !participants?.length) {
-        return res
-          .status(400)
-          .json({
-            message: "Project ID, objective, and participants are required",
-          });
+        return res.status(400).json({
+          message: "Project ID, objective, and participants are required",
+        });
       }
 
       const result = await agentOrchestrator.orchestrateTeam(

--- a/server/services/replit-ai-enhanced.ts
+++ b/server/services/replit-ai-enhanced.ts
@@ -1,6 +1,5 @@
 import { multiAIService } from "./multi-ai-provider";
 import { agentMemoryService } from "./agent-memory-service";
-import { agentToolIntegration } from "./agent-tool-integration";
 import { storage } from "../storage";
 import { nanoid } from "nanoid";
 import type { Project } from "@shared/schema";

--- a/server/services/replit-ai-enhanced.ts
+++ b/server/services/replit-ai-enhanced.ts
@@ -1,10 +1,8 @@
-import { multiAIService } from "./multi-ai-provider";
-import { agentMemoryService } from "./agent-memory-service";
-import { storage } from "../storage";
 import { nanoid } from "nanoid";
 import type { Project } from "@shared/schema";
-
-// Enhanced Replit AI System with Agent and Assistant capabilities
+import { storage } from "../storage";
+import { agentMemoryService } from "./agent-memory-service";
+import { multiAIService } from "./multi-ai-provider";
 export interface ReplitAICapabilities {
   agent: {
     naturalLanguageToApp: boolean;

--- a/server/services/replit-ai-enhanced.ts
+++ b/server/services/replit-ai-enhanced.ts
@@ -3,7 +3,6 @@ import { agentMemoryService } from "./agent-memory-service";
 import { agentToolIntegration } from "./agent-tool-integration";
 import { storage } from "../storage";
 import { nanoid } from "nanoid";
-import type { Agent } from "@shared/schema";
 
 // Enhanced Replit AI System with Agent and Assistant capabilities
 export interface ReplitAICapabilities {

--- a/server/services/replit-ai-enhanced.ts
+++ b/server/services/replit-ai-enhanced.ts
@@ -1,8 +1,8 @@
-// @ts-nocheck
 import { multiAIService } from "./multi-ai-provider";
 import { agentMemoryService } from "./agent-memory-service";
 import { agentToolIntegration } from "./agent-tool-integration";
 import { storage } from "../storage";
+import { nanoid } from "nanoid";
 import type { Agent } from "@shared/schema";
 
 // Enhanced Replit AI System with Agent and Assistant capabilities
@@ -304,7 +304,6 @@ Use modern best practices and production-ready patterns.
       language: architecture.techStack.language || "typescript",
       framework: architecture.techStack.frontend || "react",
       status: "active",
-      isPublic: false,
     });
 
     // Initialize project files structure
@@ -319,7 +318,12 @@ Use modern best practices and production-ready patterns.
     architecture: any,
     taskId: string,
   ): Promise<any> {
-    const codeGeneration = {
+    const codeGeneration: {
+      frontend: unknown[];
+      backend: unknown[];
+      config: unknown[];
+      tests: unknown[];
+    } = {
       frontend: [],
       backend: [],
       config: [],
@@ -620,13 +624,18 @@ Implement the feature completely with proper integration.
     const checkpointId = `checkpoint-${Date.now()}`;
 
     // Store checkpoint data
-    await agentMemoryService.storeMemory(0, project.id, {
-      type: "checkpoint",
-      checkpointId,
-      code: JSON.stringify(code),
-      timestamp: new Date(),
-      projectState: project,
-    });
+    await agentMemoryService.storeMemory(
+      0,
+      "project_context",
+      `Project ${project.id} checkpoint ${checkpointId}`,
+      {
+        checkpointId,
+        code: JSON.stringify(code),
+        timestamp: new Date(),
+        projectState: project,
+      },
+      project.id,
+    );
 
     return checkpointId;
   }
@@ -712,7 +721,7 @@ Implement the feature completely with proper integration.
 
   // Extract concepts from explanation
   private extractConcepts(explanation: string): string[] {
-    const concepts = [];
+    const concepts: string[] = [];
     const conceptPatterns = [
       /uses?\s+(\w+)/gi,
       /implements?\s+(\w+)/gi,
@@ -721,13 +730,13 @@ Implement the feature completely with proper integration.
     ];
 
     conceptPatterns.forEach((pattern) => {
-      const matches = explanation.matchAll(pattern);
+      const matches = Array.from(explanation.matchAll(pattern));
       for (const match of matches) {
         concepts.push(match[1]);
       }
     });
 
-    return [...new Set(concepts)];
+    return Array.from(new Set(concepts));
   }
 
   // Code diff for showing changes
@@ -774,18 +783,23 @@ Implement the feature completely with proper integration.
 
     // Store file structure metadata
     for (const file of files) {
-      await agentMemoryService.storeMemory(0, projectId, {
-        type: "project-file",
-        path: file.path,
-        fileType: file.type,
-        created: new Date(),
-      });
+      await agentMemoryService.storeMemory(
+        0,
+        "project_context",
+        `Initial file: ${file.path}`,
+        {
+          path: file.path,
+          fileType: file.type,
+          created: new Date(),
+        },
+        projectId,
+      );
     }
   }
 
   // Generate unique task ID
   private generateTaskId(): string {
-    return `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    return nanoid();
   }
 
   // Get usage statistics

--- a/server/services/replit-ai-enhanced.ts
+++ b/server/services/replit-ai-enhanced.ts
@@ -1,0 +1,817 @@
+// @ts-nocheck
+import { multiAIService } from "./multi-ai-provider";
+import { agentMemoryService } from "./agent-memory-service";
+import { agentToolIntegration } from "./agent-tool-integration";
+import { storage } from "../storage";
+import type { Agent } from "@shared/schema";
+
+// Enhanced Replit AI System with Agent and Assistant capabilities
+export interface ReplitAICapabilities {
+  agent: {
+    naturalLanguageToApp: boolean;
+    complexFeatureBuilding: boolean;
+    effortBasedPricing: boolean;
+    dynamicIntelligence: {
+      extendedThinking: boolean;
+      highPower: boolean;
+    };
+    checkpoints: boolean;
+  };
+  assistant: {
+    codeExplanation: boolean;
+    quickFixes: boolean;
+    featureAddition: boolean;
+    basicMode: boolean;
+    advancedMode: boolean;
+  };
+}
+
+export interface AITask {
+  id: string;
+  type: "agent" | "assistant";
+  mode?: "basic" | "advanced";
+  complexity: "simple" | "moderate" | "complex";
+  description: string;
+  context: any;
+  estimatedEffort: number; // 1-10 scale
+  actualEffort?: number;
+  cost?: number;
+  checkpoint?: string;
+}
+
+export class ReplitAIEnhancedSystem {
+  private capabilities: ReplitAICapabilities = {
+    agent: {
+      naturalLanguageToApp: true,
+      complexFeatureBuilding: true,
+      effortBasedPricing: true,
+      dynamicIntelligence: {
+        extendedThinking: true,
+        highPower: true,
+      },
+      checkpoints: true,
+    },
+    assistant: {
+      codeExplanation: true,
+      quickFixes: true,
+      featureAddition: true,
+      basicMode: true,
+      advancedMode: true,
+    },
+  };
+
+  private activeTasks: Map<string, AITask> = new Map();
+  private taskHistory: AITask[] = [];
+  private effortTracking: Map<string, number> = new Map();
+
+  // Enhanced Agent: Complete app generation from natural language
+  async createAppFromDescription(
+    description: string,
+    userId: number,
+  ): Promise<any> {
+    const taskId = this.generateTaskId();
+    const task: AITask = {
+      id: taskId,
+      type: "agent",
+      complexity: this.assessComplexity(description),
+      description,
+      context: { userId },
+      estimatedEffort: this.estimateEffort(description),
+    };
+
+    this.activeTasks.set(taskId, task);
+
+    try {
+      // Step 1: Analyze requirements using multiple AI providers
+      const requirements = await this.analyzeRequirements(description);
+
+      // Step 2: Generate architecture and plan
+      const architecture = await this.generateArchitecture(requirements);
+
+      // Step 3: Create project structure
+      const project = await this.createProjectStructure(architecture, userId);
+
+      // Step 4: Generate code with checkpoints
+      const generatedCode = await this.generateCompleteApp(
+        project,
+        architecture,
+        taskId,
+      );
+
+      // Step 5: Set up environment and dependencies
+      await this.setupEnvironment(project);
+
+      // Calculate actual effort and cost
+      task.actualEffort = this.calculateActualEffort(taskId);
+      task.cost = this.calculateCost(task);
+      task.checkpoint = await this.createCheckpoint(project, generatedCode);
+
+      this.taskHistory.push(task);
+      this.activeTasks.delete(taskId);
+
+      return {
+        project,
+        code: generatedCode,
+        checkpoint: task.checkpoint,
+        effort: task.actualEffort,
+        cost: task.cost,
+      };
+    } catch (error) {
+      this.activeTasks.delete(taskId);
+      throw error;
+    }
+  }
+
+  // Enhanced Assistant: Context-aware code assistance
+  async assistWithCode(request: {
+    code: string;
+    language: string;
+    action: "explain" | "fix" | "add-feature";
+    mode: "basic" | "advanced";
+    context?: any;
+  }): Promise<any> {
+    const taskId = this.generateTaskId();
+    const task: AITask = {
+      id: taskId,
+      type: "assistant",
+      mode: request.mode,
+      complexity: "simple",
+      description: `${request.action} for ${request.language} code`,
+      context: request.context,
+      estimatedEffort: request.mode === "basic" ? 0 : 1,
+    };
+
+    this.activeTasks.set(taskId, task);
+
+    try {
+      let result: any;
+
+      switch (request.action) {
+        case "explain":
+          result = await this.explainCode(request.code, request.language);
+          break;
+        case "fix":
+          if (request.mode === "basic") {
+            result = await this.suggestFixes(request.code, request.language);
+          } else {
+            result = await this.applyFixes(request.code, request.language);
+            task.cost = 0.05; // $0.05 per advanced edit
+          }
+          break;
+        case "add-feature":
+          if (request.mode === "basic") {
+            result = await this.suggestFeature(request.code, request.language);
+          } else {
+            result = await this.implementFeature(
+              request.code,
+              request.language,
+              request.context,
+            );
+            task.cost = 0.05; // $0.05 per advanced edit
+          }
+          break;
+      }
+
+      task.actualEffort = this.calculateActualEffort(taskId);
+      this.taskHistory.push(task);
+      this.activeTasks.delete(taskId);
+
+      return {
+        result,
+        mode: request.mode,
+        cost: task.cost || 0,
+      };
+    } catch (error) {
+      this.activeTasks.delete(taskId);
+      throw error;
+    }
+  }
+
+  // Intelligent complexity assessment
+  private assessComplexity(
+    description: string,
+  ): "simple" | "moderate" | "complex" {
+    const complexityIndicators = {
+      simple: ["basic", "simple", "landing page", "static", "display"],
+      moderate: ["crud", "api", "database", "authentication", "responsive"],
+      complex: [
+        "real-time",
+        "ai",
+        "machine learning",
+        "payment",
+        "integration",
+        "multi-user",
+        "websocket",
+      ],
+    };
+
+    const lowerDesc = description.toLowerCase();
+
+    for (const [level, keywords] of Object.entries(complexityIndicators)) {
+      if (keywords.some((keyword) => lowerDesc.includes(keyword))) {
+        return level as "simple" | "moderate" | "complex";
+      }
+    }
+
+    return "moderate";
+  }
+
+  // Effort estimation (1-10 scale)
+  private estimateEffort(description: string): number {
+    const complexity = this.assessComplexity(description);
+    const baseEffort = {
+      simple: 2,
+      moderate: 5,
+      complex: 8,
+    };
+
+    // Adjust based on description length and specificity
+    const wordCount = description.split(" ").length;
+    const adjustment = Math.min(wordCount / 50, 2); // Max 2 points adjustment
+
+    return Math.min(baseEffort[complexity] + adjustment, 10);
+  }
+
+  // Multi-provider requirement analysis
+  private async analyzeRequirements(description: string): Promise<any> {
+    const prompts = {
+      openai: `Analyze this app requirement and extract key features, tech stack, and architecture:
+"${description}"
+
+Respond with JSON:
+{
+  "features": ["list of main features"],
+  "techStack": {"frontend": "...", "backend": "...", "database": "..."},
+  "architecture": "description of recommended architecture",
+  "integrations": ["required third-party services"],
+  "complexity": "simple|moderate|complex"
+}`,
+      claude: `As a product architect, analyze this app idea and provide detailed requirements:
+"${description}"
+
+Focus on user experience, design patterns, and scalability.`,
+      gemini: `Analyze technical requirements and performance considerations for:
+"${description}"
+
+Include optimization strategies and deployment recommendations.`,
+    };
+
+    const analyses = await Promise.all([
+      multiAIService.generateResponseWithFallback(prompts.openai, "", "openai"),
+      multiAIService.generateResponseWithFallback(prompts.claude, "", "claude"),
+      multiAIService.generateResponseWithFallback(prompts.gemini, "", "gemini"),
+    ]);
+
+    // Merge insights from all providers
+    return this.mergeAnalyses(analyses);
+  }
+
+  // Architecture generation with best practices
+  private async generateArchitecture(requirements: any): Promise<any> {
+    const architecturePrompt = `
+Based on these requirements:
+${JSON.stringify(requirements, null, 2)}
+
+Generate a complete application architecture including:
+1. Project structure
+2. Component hierarchy
+3. API endpoints
+4. Database schema
+5. Security considerations
+6. Performance optimizations
+
+Use modern best practices and production-ready patterns.
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      architecturePrompt,
+      "You are an expert software architect.",
+      "openai",
+    );
+
+    return JSON.parse(response.content);
+  }
+
+  // Create project with proper structure
+  private async createProjectStructure(
+    architecture: any,
+    userId: number,
+  ): Promise<any> {
+    const project = await storage.createProject({
+      userId,
+      name: architecture.projectName || "AI Generated App",
+      description: architecture.description,
+      language: architecture.techStack.language || "typescript",
+      framework: architecture.techStack.frontend || "react",
+      status: "active",
+      isPublic: false,
+    });
+
+    // Initialize project files structure
+    await this.initializeProjectFiles(project.id, architecture);
+
+    return project;
+  }
+
+  // Generate complete application code
+  private async generateCompleteApp(
+    project: any,
+    architecture: any,
+    taskId: string,
+  ): Promise<any> {
+    const codeGeneration = {
+      frontend: [],
+      backend: [],
+      config: [],
+      tests: [],
+    };
+
+    // Track effort for each component
+    this.effortTracking.set(taskId, 0);
+
+    // Generate frontend components
+    for (const component of architecture.components || []) {
+      const code = await this.generateComponent(
+        component,
+        architecture.techStack,
+      );
+      codeGeneration.frontend.push(code);
+      this.incrementEffort(taskId, 0.5);
+    }
+
+    // Generate backend API
+    if (architecture.api) {
+      const apiCode = await this.generateAPI(
+        architecture.api,
+        architecture.techStack,
+      );
+      codeGeneration.backend.push(apiCode);
+      this.incrementEffort(taskId, 1);
+    }
+
+    // Generate configuration files
+    const configs = await this.generateConfigs(architecture);
+    codeGeneration.config = configs;
+    this.incrementEffort(taskId, 0.3);
+
+    // Store generated code
+    await storage.createCodeGeneration({
+      userId: project.userId,
+      projectId: project.id,
+      prompt: JSON.stringify(architecture),
+      language: architecture.techStack.language,
+      framework: architecture.techStack.frontend,
+      generatedCode: JSON.stringify(codeGeneration),
+    });
+
+    return codeGeneration;
+  }
+
+  // Component generation with modern patterns
+  private async generateComponent(
+    component: any,
+    techStack: any,
+  ): Promise<any> {
+    const componentPrompt = `
+Generate a ${techStack.frontend} component:
+Name: ${component.name}
+Type: ${component.type}
+Props: ${JSON.stringify(component.props)}
+Features: ${component.features?.join(", ")}
+
+Use TypeScript, modern hooks, and best practices.
+Include proper error handling and accessibility.
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      componentPrompt,
+      "You are an expert frontend developer.",
+      "claude", // Claude excels at UI/UX code
+    );
+
+    return {
+      name: component.name,
+      code: response.content,
+      type: component.type,
+    };
+  }
+
+  // API generation with proper patterns
+  private async generateAPI(apiSpec: any, techStack: any): Promise<any> {
+    const apiPrompt = `
+Generate a RESTful API with these endpoints:
+${JSON.stringify(apiSpec.endpoints, null, 2)}
+
+Tech stack: ${techStack.backend}
+Database: ${techStack.database}
+
+Include:
+- Proper error handling
+- Input validation
+- Authentication middleware
+- Database queries
+- TypeScript types
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      apiPrompt,
+      "You are an expert backend developer.",
+      "openai", // OpenAI excels at API design
+    );
+
+    return {
+      endpoints: apiSpec.endpoints,
+      code: response.content,
+    };
+  }
+
+  // Configuration file generation
+  private async generateConfigs(architecture: any): Promise<any[]> {
+    const configs = [];
+
+    // Package.json
+    configs.push({
+      name: "package.json",
+      content: JSON.stringify(
+        {
+          name: architecture.projectName.toLowerCase().replace(/\s+/g, "-"),
+          version: "1.0.0",
+          scripts: {
+            dev: "vite",
+            build: "vite build",
+            preview: "vite preview",
+          },
+          dependencies: architecture.dependencies || {},
+          devDependencies: architecture.devDependencies || {},
+        },
+        null,
+        2,
+      ),
+    });
+
+    // TypeScript config
+    if (architecture.techStack.language === "typescript") {
+      configs.push({
+        name: "tsconfig.json",
+        content: JSON.stringify(
+          {
+            compilerOptions: {
+              target: "ES2020",
+              module: "ESNext",
+              strict: true,
+              jsx: "react-jsx",
+              moduleResolution: "node",
+              resolveJsonModule: true,
+              esModuleInterop: true,
+              skipLibCheck: true,
+            },
+          },
+          null,
+          2,
+        ),
+      });
+    }
+
+    return configs;
+  }
+
+  // Environment setup
+  private async setupEnvironment(project: any): Promise<void> {
+    // This would integrate with actual package managers and build tools
+    console.log(`Setting up environment for project ${project.id}`);
+
+    // Create necessary directories
+    // Install dependencies
+    // Set up build scripts
+    // Configure development server
+  }
+
+  // Code explanation (free in basic mode)
+  private async explainCode(code: string, language: string): Promise<any> {
+    const prompt = `
+Explain this ${language} code in simple terms:
+\`\`\`${language}
+${code}
+\`\`\`
+
+Provide:
+1. What the code does
+2. How it works
+3. Key concepts used
+4. Potential improvements
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      prompt,
+      "You are a helpful coding teacher.",
+      "openai",
+    );
+
+    return {
+      explanation: response.content,
+      language,
+      concepts: this.extractConcepts(response.content),
+    };
+  }
+
+  // Suggest fixes (basic mode)
+  private async suggestFixes(code: string, language: string): Promise<any> {
+    const prompt = `
+Analyze this ${language} code for issues:
+\`\`\`${language}
+${code}
+\`\`\`
+
+Suggest fixes for any bugs, performance issues, or best practice violations.
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      prompt,
+      "You are an expert code reviewer.",
+      "openai",
+    );
+
+    return {
+      suggestions: response.content,
+      severity: "info",
+    };
+  }
+
+  // Apply fixes (advanced mode - costs $0.05)
+  private async applyFixes(code: string, language: string): Promise<any> {
+    const prompt = `
+Fix all issues in this ${language} code:
+\`\`\`${language}
+${code}
+\`\`\`
+
+Return the corrected code with comments explaining the fixes.
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      prompt,
+      "You are an expert developer who writes clean, bug-free code.",
+      "claude", // Claude excels at code quality
+    );
+
+    return {
+      originalCode: code,
+      fixedCode: response.content,
+      changes: this.diffCode(code, response.content),
+    };
+  }
+
+  // Suggest feature (basic mode)
+  private async suggestFeature(code: string, language: string): Promise<any> {
+    const prompt = `
+Suggest a useful feature to add to this ${language} code:
+\`\`\`${language}
+${code}
+\`\`\`
+
+Describe what the feature would do and how to implement it.
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      prompt,
+      "You are a creative developer.",
+      "claude",
+    );
+
+    return {
+      suggestion: response.content,
+      complexity: "moderate",
+    };
+  }
+
+  // Implement feature (advanced mode - costs $0.05)
+  private async implementFeature(
+    code: string,
+    language: string,
+    context: any,
+  ): Promise<any> {
+    const prompt = `
+Add this feature to the ${language} code:
+${context.featureDescription}
+
+Current code:
+\`\`\`${language}
+${code}
+\`\`\`
+
+Implement the feature completely with proper integration.
+`;
+
+    const response = await multiAIService.generateResponseWithFallback(
+      prompt,
+      "You are an expert developer who implements features perfectly.",
+      "openai",
+    );
+
+    return {
+      originalCode: code,
+      updatedCode: response.content,
+      featureAdded: context.featureDescription,
+    };
+  }
+
+  // Checkpoint creation for rollback
+  private async createCheckpoint(project: any, code: any): Promise<string> {
+    const checkpointId = `checkpoint-${Date.now()}`;
+
+    // Store checkpoint data
+    await agentMemoryService.storeMemory(0, project.id, {
+      type: "checkpoint",
+      checkpointId,
+      code: JSON.stringify(code),
+      timestamp: new Date(),
+      projectState: project,
+    });
+
+    return checkpointId;
+  }
+
+  // Effort tracking
+  private incrementEffort(taskId: string, amount: number): void {
+    const current = this.effortTracking.get(taskId) || 0;
+    this.effortTracking.set(taskId, current + amount);
+  }
+
+  private calculateActualEffort(taskId: string): number {
+    return this.effortTracking.get(taskId) || 0;
+  }
+
+  // Cost calculation based on effort
+  private calculateCost(task: AITask): number {
+    if (task.type === "assistant" && task.mode === "basic") {
+      return 0; // Basic assistant mode is free
+    }
+
+    if (task.type === "assistant" && task.mode === "advanced") {
+      return 0.05; // Fixed price for advanced assistant
+    }
+
+    // Agent pricing based on effort
+    const effortCost = {
+      simple: 0.1, // $0.10 for simple tasks
+      moderate: 0.5, // $0.50 for moderate tasks
+      complex: 2.0, // $2.00 for complex tasks
+    };
+
+    const baseCost = effortCost[task.complexity];
+    const effortMultiplier = task.actualEffort || task.estimatedEffort;
+
+    return baseCost * (effortMultiplier / 5); // Normalized to 5 as average
+  }
+
+  // Merge analyses from multiple AI providers
+  private mergeAnalyses(analyses: any[]): any {
+    // Intelligent merging of insights from different providers
+    const merged = {
+      features: new Set(),
+      techStack: {},
+      architecture: "",
+      integrations: new Set(),
+      complexity: "moderate",
+    };
+
+    analyses.forEach((analysis) => {
+      try {
+        const parsed =
+          typeof analysis.content === "string"
+            ? JSON.parse(analysis.content)
+            : analysis.content;
+
+        if (parsed.features) {
+          parsed.features.forEach((f: string) => merged.features.add(f));
+        }
+
+        if (parsed.techStack) {
+          Object.assign(merged.techStack, parsed.techStack);
+        }
+
+        if (parsed.integrations) {
+          parsed.integrations.forEach((i: string) =>
+            merged.integrations.add(i),
+          );
+        }
+      } catch (e) {
+        // Handle non-JSON responses
+        console.log("Non-JSON analysis response:", analysis);
+      }
+    });
+
+    return {
+      features: Array.from(merged.features),
+      techStack: merged.techStack,
+      architecture: merged.architecture,
+      integrations: Array.from(merged.integrations),
+      complexity: merged.complexity,
+    };
+  }
+
+  // Extract concepts from explanation
+  private extractConcepts(explanation: string): string[] {
+    const concepts = [];
+    const conceptPatterns = [
+      /uses?\s+(\w+)/gi,
+      /implements?\s+(\w+)/gi,
+      /pattern:\s*(\w+)/gi,
+      /concept:\s*(\w+)/gi,
+    ];
+
+    conceptPatterns.forEach((pattern) => {
+      const matches = explanation.matchAll(pattern);
+      for (const match of matches) {
+        concepts.push(match[1]);
+      }
+    });
+
+    return [...new Set(concepts)];
+  }
+
+  // Code diff for showing changes
+  private diffCode(original: string, updated: string): any {
+    const originalLines = original.split("\n");
+    const updatedLines = updated.split("\n");
+    const changes = [];
+
+    // Simple line-by-line diff
+    const maxLines = Math.max(originalLines.length, updatedLines.length);
+
+    for (let i = 0; i < maxLines; i++) {
+      if (originalLines[i] !== updatedLines[i]) {
+        changes.push({
+          line: i + 1,
+          original: originalLines[i] || "",
+          updated: updatedLines[i] || "",
+          type: !originalLines[i]
+            ? "added"
+            : !updatedLines[i]
+              ? "removed"
+              : "modified",
+        });
+      }
+    }
+
+    return changes;
+  }
+
+  // Initialize project files
+  private async initializeProjectFiles(
+    projectId: number,
+    architecture: any,
+  ): Promise<void> {
+    // Create initial file structure based on architecture
+    const files = [
+      { path: "src/index.tsx", type: "file" },
+      { path: "src/App.tsx", type: "file" },
+      { path: "src/components/", type: "folder" },
+      { path: "src/styles/", type: "folder" },
+      { path: "public/", type: "folder" },
+      { path: "README.md", type: "file" },
+    ];
+
+    // Store file structure metadata
+    for (const file of files) {
+      await agentMemoryService.storeMemory(0, projectId, {
+        type: "project-file",
+        path: file.path,
+        fileType: file.type,
+        created: new Date(),
+      });
+    }
+  }
+
+  // Generate unique task ID
+  private generateTaskId(): string {
+    return `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  // Get usage statistics
+  async getUsageStats(userId: number): Promise<any> {
+    const userTasks = this.taskHistory.filter(
+      (task) => task.context?.userId === userId,
+    );
+
+    const stats = {
+      totalTasks: userTasks.length,
+      agentTasks: userTasks.filter((t) => t.type === "agent").length,
+      assistantTasks: userTasks.filter((t) => t.type === "assistant").length,
+      totalCost: userTasks.reduce((sum, task) => sum + (task.cost || 0), 0),
+      averageEffort:
+        userTasks.reduce((sum, task) => sum + (task.actualEffort || 0), 0) /
+        userTasks.length,
+      complexityBreakdown: {
+        simple: userTasks.filter((t) => t.complexity === "simple").length,
+        moderate: userTasks.filter((t) => t.complexity === "moderate").length,
+        complex: userTasks.filter((t) => t.complexity === "complex").length,
+      },
+    };
+
+    return stats;
+  }
+}
+
+// Export singleton instance
+export const replitAIEnhanced = new ReplitAIEnhancedSystem();


### PR DESCRIPTION
## Summary
- restore enhanced Replit AI service and API endpoints
- generate and execute development roadmaps with agent sessions
- register Replit AI router in main server routes

## Testing
- `npx prettier server/services/replit-ai-enhanced.ts server/api/replit-ai-enhanced.ts server/routes.ts -w`
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: multiple TypeScript errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6890296cb8a883278d7dfb3f004c9a55